### PR TITLE
Create .stylelintignore

### DIFF
--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,0 +1,5 @@
+node_modules/
+
+# Client build files
+client/build/
+/vendor


### PR DESCRIPTION
Ignore composer and NPM dependency assets when linting, as well as built assets. Also significantly speeds up builds locally as a result